### PR TITLE
API file saving fix

### DIFF
--- a/ElectronicObserver/Observer/APIObserver.cs
+++ b/ElectronicObserver/Observer/APIObserver.cs
@@ -909,10 +909,12 @@ public sealed class APIObserver
 								Directory.CreateDirectory(Path.GetDirectoryName(tpath));
 
 								//System.Diagnostics.Debug.WriteLine( oSession.fullUrl + " => " + tpath );
-								using (var sw = new System.IO.BinaryWriter(System.IO.File.OpenWrite(tpath)))
+								/*using (var sw = new System.IO.BinaryWriter(System.IO.File.OpenWrite(tpath)))
 								{
 									sw.Write(responseCopy);
-								}
+								}*/
+
+								File.WriteAllBytesAsync(tpath, responseCopy);
 							}
 
 							Utility.Logger.Add(1, string.Format(LoggerRes.SavedAPI, tpath.Remove(0, saveDataPath.Length + 1)));

--- a/ElectronicObserver/Observer/APIObserver.cs
+++ b/ElectronicObserver/Observer/APIObserver.cs
@@ -909,11 +909,6 @@ public sealed class APIObserver
 								Directory.CreateDirectory(Path.GetDirectoryName(tpath));
 
 								//System.Diagnostics.Debug.WriteLine( oSession.fullUrl + " => " + tpath );
-								/*using (var sw = new System.IO.BinaryWriter(System.IO.File.OpenWrite(tpath)))
-								{
-									sw.Write(responseCopy);
-								}*/
-
 								File.WriteAllBytesAsync(tpath, responseCopy);
 							}
 


### PR DESCRIPTION
Saving "other files" on response writes files over existing one without deleting them first