### PR TITLE
Ship remodel notification translation

### DIFF
--- a/ElectronicObserver/Notifier/NotifierRemodelLevel.cs
+++ b/ElectronicObserver/Notifier/NotifierRemodelLevel.cs
@@ -40,7 +40,7 @@ public class NotifierRemodelLevel : NotifierBase
 
 	private void Notify(IShipData ship, IShipDataMaster nextRemodelShip)
 	{
-		DialogData.Message = string.Format(NotifierRes.RemodelText, ship.Name, nextRemodelShip.Name);
+		DialogData.Message = string.Format(NotifierRes.RemodelText, ship.Name, nextRemodelShip.NameEN);
 
 		base.Notify();
 	}


### PR DESCRIPTION
When reaching the remodel level of a ship, the remodel name always displays in japanese

![image](https://user-images.githubusercontent.com/22751386/178202599-71ec0424-457e-44d0-9447-62c694c092c0.png)
