### PR TITLE
Fixing A3/A5/A6 conditions

### DIFF
--- a/ElectronicObserver/Data/MissionClearCondition.cs
+++ b/ElectronicObserver/Data/MissionClearCondition.cs
@@ -731,11 +731,13 @@ public static class MissionClearCondition
 			int escort = Members.Count(s => s.MasterShip.ShipType == ShipTypes.Escort);
 			int escortAircraftCarrier = Members.Count(s => s.MasterShip.ShipType == ShipTypes.LightAircraftCarrier && s.ASWBase > 0);
 
-			bool baseRequirementMet = includeDEsInBaseRequirement switch
+			int baseRequirementDestoyerAndEscortCount = includeDEsInBaseRequirement switch
 			{
-				true => (destroyer + escort) >= 3,
-				_ => destroyer >= 3,
-			} && lightCruiser >= 1;
+				true => destroyer + escort,
+				_ => destroyer,
+			};
+
+			bool baseRequirementMet = baseRequirementDestoyerAndEscortCount >= 3 && lightCruiser >= 1;
 
 			Assert(
 				baseRequirementMet ||


### PR DESCRIPTION
From what I understand, a condition for those two expeditions was wrong because those conditions were based on A3's : 
- CL 3DE/DD 

or one of

- DD 3DE
- CL 2DE
- CT 2DD
- CVE 2DE
- CVE 2DD

CL 2DE substitution requirement seems to override A3's requirement of CL 3DE/DD ? If that's the case we're only left with an actual requirement of CL 3DD which is the same for A5 & A6

<img width="395" height="558" alt="image" src="https://github.com/user-attachments/assets/8f307c5a-f92f-4b6b-9759-03e5df91bd07" />

