### PR TITLE
Home port supply timer

### DIFF
--- a/ElectronicObserver/Data/FleetData.cs
+++ b/ElectronicObserver/Data/FleetData.cs
@@ -230,10 +230,19 @@ public class FleetData : APIWrapper, IIdentifiable, IFleetData
 
 					}
 
+					// 随伴艦一括解除を除く
+					if (shipID != -2)
+					{
+						if (IsFlagshipRepairShip)
+						{
+							KCDatabase.Instance.Fleet.StartAnchorageRepairingTimer();
+						}
 
-					if (shipID != -2 && IsFlagshipRepairShip)        //随伴艦一括解除を除く
-						KCDatabase.Instance.Fleet.StartAnchorageRepairingTimer();
-
+						if (HasNosakiSparklePosition)
+						{
+							KCDatabase.Instance.Fleet.StartHomePortSupplyTimer();
+						}
+					}
 				}
 				else
 				{
@@ -247,12 +256,23 @@ public class FleetData : APIWrapper, IIdentifiable, IFleetData
 							{
 
 								if (replacedID != -1)
+								{
 									_members[i] = replacedID;
+								}
 								else
+								{
 									RemoveShip(i);
+								}
 
 								if (IsFlagshipRepairShip)
+								{
 									KCDatabase.Instance.Fleet.StartAnchorageRepairingTimer();
+								}
+
+								if (HasNosakiSparklePosition)
+								{
+									KCDatabase.Instance.Fleet.StartHomePortSupplyTimer();
+								}
 
 								break;
 							}
@@ -427,14 +447,12 @@ public class FleetData : APIWrapper, IIdentifiable, IFleetData
 	/// <summary>
 	/// 旗艦が工作艦か
 	/// </summary>
-	public bool IsFlagshipRepairShip
-	{
-		get
-		{
-			ShipData flagship = KCDatabase.Instance.Ships[_members[0]];
-			return flagship != null && flagship.MasterShip.ShipType == ShipTypes.RepairShip;
-		}
-	}
+	public bool IsFlagshipRepairShip => KCDatabase.Instance.Ships[_members[0]]?.MasterShip.ShipType is ShipTypes.RepairShip;
+
+	private bool HasNosakiSparklePosition => MembersInstance
+		?.Take(2)
+		.Any(s => s?.MasterShip.ShipId is ShipId.Nosaki or ShipId.NosakiKai)
+		?? false;
 
 	/// <summary>
 	/// 泊地修理が発動可能か

--- a/ElectronicObserver/Data/FleetManager.cs
+++ b/ElectronicObserver/Data/FleetManager.cs
@@ -24,6 +24,11 @@ public class FleetManager : APIWrapper
 	/// </summary>
 	public DateTime AnchorageRepairingTimer { get; private set; }
 
+	/// <summary>
+	/// 泊地修理タイマ
+	/// </summary>
+	public DateTime HomePortSupplyTimer { get; private set; }
+
 
 
 	/// <summary> 更新直前の艦船データ </summary>
@@ -71,6 +76,7 @@ public class FleetManager : APIWrapper
 	{
 		Fleets = new IDDictionary<FleetData>();
 		AnchorageRepairingTimer = DateTime.MinValue;
+		HomePortSupplyTimer = DateTime.MinValue;
 
 		ConditionPredictMin = 0;
 		ConditionPredictMax = ConditionHealingSpan.TotalSeconds * 2;
@@ -160,11 +166,19 @@ public class FleetManager : APIWrapper
 		// 泊地修理・コンディションの処理
 		if (apiname == "api_port/port")
 		{
+			if ((DateTime.Now - HomePortSupplyTimer).TotalMinutes >= 15)
+			{
+				StartHomePortSupplyTimer();
+			}
 
 			if ((DateTime.Now - AnchorageRepairingTimer).TotalMinutes >= 20)
+			{
 				StartAnchorageRepairingTimer();
+			}
 			else
+			{
 				CheckAnchorageRepairingHealing();
+			}
 
 			UpdateConditionPrediction();
 		}
@@ -229,6 +243,11 @@ public class FleetManager : APIWrapper
 	public void StartAnchorageRepairingTimer()
 	{
 		AnchorageRepairingTimer = DateTime.Now;
+	}
+
+	public void StartHomePortSupplyTimer()
+	{
+		HomePortSupplyTimer = DateTime.Now;
 	}
 
 	/// <summary>

--- a/ElectronicObserver/Properties/Window/Dialog/ConfigurationResources.en.resx
+++ b/ElectronicObserver/Properties/Window/Dialog/ConfigurationResources.en.resx
@@ -794,4 +794,10 @@ When enabled, the preview will be ignored and all compositions will be shown.</v
   <data name="Control_DiscordRPC_Secretary" xml:space="preserve">
     <value>Secretary</value>
   </data>
+  <data name="FormFleet_ShowHomePortSupplyTimer" xml:space="preserve">
+    <value>Supply timer</value>
+  </data>
+  <data name="FormFleet_ShowHomePortSupplyTimerToolTip" xml:space="preserve">
+    <value>Show home port supply timer in the fleet list window.</value>
+  </data>
 </root>

--- a/ElectronicObserver/Properties/Window/Dialog/ConfigurationResources.resx
+++ b/ElectronicObserver/Properties/Window/Dialog/ConfigurationResources.resx
@@ -809,4 +809,10 @@ APIリストの書式や用法はオンラインヘルプを参照してくだ�
   <data name="Control_DiscordRPC_Secretary" xml:space="preserve">
     <value>秘書艦</value>
   </data>
+  <data name="FormFleet_ShowHomePortSupplyTimer" xml:space="preserve">
+    <value>母港給糧タイマを表示する</value>
+  </data>
+  <data name="FormFleet_ShowHomePortSupplyTimerToolTip" xml:space="preserve">
+    <value>艦隊一覧の母港給糧タイマを表示するかを指定します。</value>
+  </data>
 </root>

--- a/ElectronicObserver/Properties/Window/FleetOverviewResources.en.resx
+++ b/ElectronicObserver/Properties/Window/FleetOverviewResources.en.resx
@@ -135,13 +135,18 @@ Formula 33:
  n=4: {9:f2}</value>
   </data>
   <data name="AnchorageRepairToolTip" xml:space="preserve">
-    <value>Anchorage Repair Timer
-Start: </value>
+    <value>Anchorage Repair Timer</value>
   </data>
   <data name="Recovery" xml:space="preserve">
     <value>Recovery</value>
   </data>
   <data name="LandingOperationTooltip" xml:space="preserve">
     <value>Landing operation</value>
+  </data>
+  <data name="TimerStart" xml:space="preserve">
+    <value>Start</value>
+  </data>
+  <data name="HomePortSupplyToolTip" xml:space="preserve">
+    <value>Home port supply timer</value>
   </data>
 </root>

--- a/ElectronicObserver/Properties/Window/FleetOverviewResources.es-ES.resx
+++ b/ElectronicObserver/Properties/Window/FleetOverviewResources.es-ES.resx
@@ -135,13 +135,15 @@ Fórmula 33:
  n=4: {9:f2}</value>
   </data>
   <data name="AnchorageRepairToolTip" xml:space="preserve">
-    <value>Temporizador de reparación del anclaje
-Inicio:</value>
+    <value>Temporizador de reparación del anclaje</value>
   </data>
   <data name="Recovery" xml:space="preserve">
     <value>Recuperación</value>
   </data>
   <data name="LandingOperationTooltip" xml:space="preserve">
     <value>Landing operation</value>
+  </data>
+  <data name="TimerStart" xml:space="preserve">
+    <value>Inicio</value>
   </data>
 </root>

--- a/ElectronicObserver/Properties/Window/FleetOverviewResources.ko-KR.resx
+++ b/ElectronicObserver/Properties/Window/FleetOverviewResources.ko-KR.resx
@@ -135,13 +135,15 @@
 　분기점계수4: {9:f2}</value>
   </data>
   <data name="AnchorageRepairToolTip" xml:space="preserve">
-    <value>정박지 수리 타이머
-개시:</value>
+    <value>정박지 수리 타이머</value>
   </data>
   <data name="Recovery" xml:space="preserve">
     <value>회복</value>
   </data>
   <data name="LandingOperationTooltip" xml:space="preserve">
     <value>전차 유송량(TP)</value>
+  </data>
+  <data name="TimerStart" xml:space="preserve">
+    <value>개시</value>
   </data>
 </root>

--- a/ElectronicObserver/Properties/Window/FleetOverviewResources.resx
+++ b/ElectronicObserver/Properties/Window/FleetOverviewResources.resx
@@ -135,13 +135,18 @@
 　分岐点係数4: {9:f2}</value>
   </data>
   <data name="AnchorageRepairToolTip" xml:space="preserve">
-    <value>泊地修理タイマ
-開始: </value>
+    <value>泊地修理タイマ</value>
   </data>
   <data name="Recovery" xml:space="preserve">
     <value>回復</value>
   </data>
   <data name="LandingOperationTooltip" xml:space="preserve">
     <value>戦車輸送量(TP)</value>
+  </data>
+  <data name="HomePortSupplyToolTip" xml:space="preserve">
+    <value>母港給糧タイマ</value>
+  </data>
+  <data name="TimerStart" xml:space="preserve">
+    <value>開始</value>
   </data>
 </root>

--- a/ElectronicObserver/Properties/Window/FleetOverviewResources.zh-CN.resx
+++ b/ElectronicObserver/Properties/Window/FleetOverviewResources.zh-CN.resx
@@ -135,13 +135,15 @@
 分歧点系数4：{9:f2}</value>
   </data>
   <data name="AnchorageRepairToolTip" xml:space="preserve">
-    <value>泊地修理计时器
-开始: </value>
+    <value>泊地修理计时器</value>
   </data>
   <data name="Recovery" xml:space="preserve">
     <value>恢复</value>
   </data>
   <data name="LandingOperationTooltip" xml:space="preserve">
     <value>Landing operation</value>
+  </data>
+  <data name="TimerStart" xml:space="preserve">
+    <value>开始</value>
   </data>
 </root>

--- a/ElectronicObserver/Utility/Configuration.cs
+++ b/ElectronicObserver/Utility/Configuration.cs
@@ -1021,6 +1021,11 @@ public sealed class Configuration
 			public bool ShowAnchorageRepairingTimer { get; set; }
 
 			/// <summary>
+			/// 泊地修理タイマを表示するか
+			/// </summary>
+			public bool ShowHomePortSupplyTimer { get; set; }
+
+			/// <summary>
 			/// タイマー完了時に点滅させるか
 			/// </summary>
 			public bool BlinkAtCompletion { get; set; }
@@ -1106,6 +1111,7 @@ public sealed class Configuration
 				ShowAircraftLevelByNumber = false;
 				AirSuperiorityMethod = 1;
 				ShowAnchorageRepairingTimer = true;
+				ShowHomePortSupplyTimer = true;
 				BlinkAtCompletion = true;
 				ShowConditionIcon = true;
 				FixedShipNameWidth = 40;

--- a/ElectronicObserver/Window/Settings/SubWindow/Fleet/ConfigurationFleetTranslationViewModel.cs
+++ b/ElectronicObserver/Window/Settings/SubWindow/Fleet/ConfigurationFleetTranslationViewModel.cs
@@ -25,6 +25,9 @@ public class ConfigurationFleetTranslationViewModel : TranslationBaseViewModel
 	public string FormFleet_ShowAnchorageRepairingTimer => ConfigurationResources.FormFleet_ShowAnchorageRepairingTimer;
 	public string FormFleet_ShowAnchorageRepairingTimerToolTip => ConfigurationResources.FormFleet_ShowAnchorageRepairingTimerToolTip;
 
+	public string FormFleet_ShowHomePortSupplyTimer => ConfigurationResources.FormFleet_ShowHomePortSupplyTimer;
+	public string FormFleet_ShowHomePortSupplyTimerToolTip => ConfigurationResources.FormFleet_ShowHomePortSupplyTimerToolTip;
+
 	public string FormFleet_BlinkAtDamaged => ConfigurationResources.FormFleet_BlinkAtDamaged;
 	public string FormFleet_BlinkAtDamagedToolTip => ConfigurationResources.FormFleet_BlinkAtDamagedToolTip;
 

--- a/ElectronicObserver/Window/Settings/SubWindow/Fleet/ConfigurationFleetUserControl.xaml
+++ b/ElectronicObserver/Window/Settings/SubWindow/Fleet/ConfigurationFleetUserControl.xaml
@@ -185,6 +185,14 @@
 				IsChecked="{Binding ShowAircraftLevelByNumber}"
 				ToolTip="{Binding Translation.FormFleet_ShowAircraftLevelByNumberToolTip}"
 				/>
+
+			<CheckBox
+				Grid.Row="5"
+				Grid.Column="2"
+				Content="{Binding Translation.FormFleet_ShowHomePortSupplyTimer}"
+				IsChecked="{Binding ShowHomePortSupplyTimer}"
+				ToolTip="{Binding Translation.FormFleet_ShowHomePortSupplyTimerToolTip}"
+				/>
 		</Grid>
 
 		<GroupBox Grid.Row="4" Header="{Binding Translation.FormFleet_ShowTankTp}">

--- a/ElectronicObserver/Window/Settings/SubWindow/Fleet/ConfigurationFleetViewModel.cs
+++ b/ElectronicObserver/Window/Settings/SubWindow/Fleet/ConfigurationFleetViewModel.cs
@@ -38,6 +38,8 @@ public partial class ConfigurationFleetViewModel : ConfigurationViewModelBase
 
 	public bool ShowAnchorageRepairingTimer { get; set; }
 
+	public bool ShowHomePortSupplyTimer { get; set; }
+
 	public bool BlinkAtCompletion { get; set; }
 
 	public bool ShowConditionIcon { get; set; }
@@ -86,6 +88,7 @@ public partial class ConfigurationFleetViewModel : ConfigurationViewModelBase
 		ShowAircraftLevelByNumber = Config.ShowAircraftLevelByNumber;
 		AirSuperiorityMethod = (AirSuperiorityMethod)Config.AirSuperiorityMethod;
 		ShowAnchorageRepairingTimer = Config.ShowAnchorageRepairingTimer;
+		ShowHomePortSupplyTimer = Config.ShowHomePortSupplyTimer;
 		BlinkAtCompletion = Config.BlinkAtCompletion;
 		ShowConditionIcon = Config.ShowConditionIcon;
 		FixedShipNameWidth = Config.FixedShipNameWidth;
@@ -111,6 +114,7 @@ public partial class ConfigurationFleetViewModel : ConfigurationViewModelBase
 		Config.ShowAircraftLevelByNumber = ShowAircraftLevelByNumber;
 		Config.AirSuperiorityMethod = (int)AirSuperiorityMethod;
 		Config.ShowAnchorageRepairingTimer = ShowAnchorageRepairingTimer;
+		Config.ShowHomePortSupplyTimer = ShowHomePortSupplyTimer;
 		Config.BlinkAtCompletion = BlinkAtCompletion;
 		Config.ShowConditionIcon = ShowConditionIcon;
 		Config.FixedShipNameWidth = FixedShipNameWidth;

--- a/ElectronicObserver/Window/Wpf/FleetOverview/FleetOverviewView.xaml
+++ b/ElectronicObserver/Window/Wpf/FleetOverview/FleetOverviewView.xaml
@@ -28,6 +28,7 @@
 				<RowDefinition Height="Auto" />
 				<RowDefinition Height="Auto" />
 				<RowDefinition Height="Auto" />
+				<RowDefinition Height="Auto" />
 			</Grid.RowDefinitions>
 
 			<ItemsControl Grid.Row="0" ItemsSource="{Binding Fleets}">
@@ -86,6 +87,31 @@
 
 			<StackPanel
 				Grid.Row="2"
+				DataContext="{Binding HomePortSupplyTimer}"
+				Visibility="{Binding Visible, Converter={StaticResource BooleanToVisibilityConverter}}"
+				>
+				<Grid>
+					<Grid.ColumnDefinitions>
+						<ColumnDefinition Width="Auto" SharedSizeGroup="FleetOverviewTag" />
+						<ColumnDefinition Width="Auto" SharedSizeGroup="FleetOverviewText" />
+					</Grid.ColumnDefinitions>
+
+					<Border
+						Grid.Column="1"
+						Background="Transparent"
+						ToolTip="{Binding ToolTip}"
+						>
+						<StackPanel Orientation="Horizontal">
+							<common:IconContentIcon Margin="2 0" Type="{Binding Icon}" />
+							<TextBlock Text="{Binding Text}" />
+						</StackPanel>
+					</Border>
+				</Grid>
+				<Separator />
+			</StackPanel>
+
+			<StackPanel
+				Grid.Row="3"
 				DataContext="{Binding CombinedTag}"
 				Visibility="{Binding Visible, Converter={StaticResource BooleanToVisibilityConverter}}"
 				>

--- a/ElectronicObserver/Window/Wpf/FleetOverview/FleetOverviewViewModel.cs
+++ b/ElectronicObserver/Window/Wpf/FleetOverview/FleetOverviewViewModel.cs
@@ -11,7 +11,6 @@ using ElectronicObserver.Observer;
 using ElectronicObserver.Resource;
 using ElectronicObserver.Utility;
 using ElectronicObserver.Utility.Data;
-using ElectronicObserver.Utility.Mathematics;
 using ElectronicObserver.ViewModels;
 using ElectronicObserver.ViewModels.Translations;
 using ElectronicObserver.Window.Wpf.Fleet;
@@ -25,6 +24,7 @@ public class FleetOverviewViewModel : AnchorableViewModel
 
 	public List<FleetViewModel> Fleets { get; }
 	public FleetOverviewItemViewModel AnchorageRepairingTimer { get; }
+	public FleetOverviewItemViewModel HomePortSupplyTimer { get; }
 	public CombinedFleetOverviewItemViewModel CombinedTag { get; }
 
 	public FleetOverviewViewModel(List<FleetViewModel> fleets) : base("Fleets", "Fleets", IconContent.FormFleet)
@@ -75,6 +75,13 @@ public class FleetOverviewViewModel : AnchorableViewModel
 			Visible = false,
 		};
 
+		HomePortSupplyTimer = new()
+		{
+			Text = "-",
+			Icon = IconContent.ConditionSparkle,
+			Visible = false,
+		};
+
 		CombinedTag = new()
 		{
 			Text = "-",
@@ -90,7 +97,8 @@ public class FleetOverviewViewModel : AnchorableViewModel
 
 	private void ConfigurationChanged()
 	{
-		AnchorageRepairingTimer.Visible = Utility.Configuration.Config.FormFleet.ShowAnchorageRepairingTimer;
+		AnchorageRepairingTimer.Visible = Configuration.Config.FormFleet.ShowAnchorageRepairingTimer;
+		HomePortSupplyTimer.Visible = Configuration.Config.FormFleet.ShowHomePortSupplyTimer;
 	}
 
 	private void Updated(string apiname, dynamic data)
@@ -127,7 +135,7 @@ public class FleetOverviewViewModel : AnchorableViewModel
 				Math.Floor(Calculator.GetSearchingAbility_New33(fleet1, 4) * 100) / 100 + Math.Floor(Calculator.GetSearchingAbility_New33(fleet2, 4) * 100) / 100,
 				radar.Sum(),
 				radar.Count(i => i > 0),
-				transport.Count(i => i> 0),
+				transport.Count(i => i > 0),
 				landing.Count(i => i > 0),
 				GetTankTpTooltip(fleet1, fleet2)
 			);
@@ -146,12 +154,24 @@ public class FleetOverviewViewModel : AnchorableViewModel
 			AnchorageRepairingTimer.Text = DateTimeHelper.ToTimeElapsedString(KCDatabase.Instance.Fleet.AnchorageRepairingTimer);
 			AnchorageRepairingTimer.Tag = KCDatabase.Instance.Fleet.AnchorageRepairingTimer;
 			AnchorageRepairingTimer.ToolTip =
-				FormFleetOverview.AnchorageRepairToolTip +
-				DateTimeHelper.TimeToCSVString(KCDatabase.Instance.Fleet.AnchorageRepairingTimer) +
-				$"\r\n{FormFleetOverview.Recovery}: " +
-				DateTimeHelper.TimeToCSVString(KCDatabase.Instance.Fleet.AnchorageRepairingTimer.AddMinutes(20));
+				$"""
+				{FleetOverviewResources.AnchorageRepairToolTip}
+				{FleetOverviewResources.TimerStart}：{DateTimeHelper.TimeToCSVString(KCDatabase.Instance.Fleet.AnchorageRepairingTimer)}
+				{FleetOverviewResources.Recovery}：{DateTimeHelper.TimeToCSVString(KCDatabase.Instance.Fleet.AnchorageRepairingTimer.AddMinutes(20))}
+				""";
 		}
 
+		if (KCDatabase.Instance.Fleet.HomePortSupplyTimer > DateTime.MinValue)
+		{
+			HomePortSupplyTimer.Text = DateTimeHelper.ToTimeElapsedString(KCDatabase.Instance.Fleet.HomePortSupplyTimer);
+			HomePortSupplyTimer.Tag = KCDatabase.Instance.Fleet.HomePortSupplyTimer;
+			HomePortSupplyTimer.ToolTip =
+				$"""
+				{FleetOverviewResources.HomePortSupplyToolTip}
+				{FleetOverviewResources.TimerStart}：{DateTimeHelper.TimeToCSVString(KCDatabase.Instance.Fleet.HomePortSupplyTimer)}
+				{FleetOverviewResources.Recovery}：{DateTimeHelper.TimeToCSVString(KCDatabase.Instance.Fleet.HomePortSupplyTimer.AddMinutes(15))}
+				""";
+		}
 	}
 
 	private string GetTankTpTooltip(IFleetData fleet1, IFleetData fleet2)
@@ -171,9 +191,14 @@ public class FleetOverviewViewModel : AnchorableViewModel
 
 	private void UpdateTimerTick()
 	{
-		if (AnchorageRepairingTimer is { Visible: true, Tag: not null })
+		if (AnchorageRepairingTimer is { Visible: true, Tag: DateTime repairTime })
 		{
-			AnchorageRepairingTimer.Text = DateTimeHelper.ToTimeElapsedString((DateTime)AnchorageRepairingTimer.Tag);
+			AnchorageRepairingTimer.Text = DateTimeHelper.ToTimeElapsedString(repairTime);
+		}
+
+		if (HomePortSupplyTimer is { Visible: true, Tag: DateTime supplyTime })
+		{
+			HomePortSupplyTimer.Text = DateTimeHelper.ToTimeElapsedString(supplyTime);
 		}
 	}
 }


### PR DESCRIPTION
This PR adds the timer only. Extra stuff like displaying things in fleet, fleet status and notifications will be added separately.

I don't fully understand how the timer is supposed to behave in more advanced scenarios, so I just copied the anchorage repair timer behavior. This should work for the most common case, and everything else can be fixed later.