### PR TITLE
Changed KCRDB quest data submission logic

### DIFF
--- a/ElectronicObserver/Data/KCReplayDbSubmission/KCReplayDbQuestSubmission/KCReplayDbQuestSubmissionService.cs
+++ b/ElectronicObserver/Data/KCReplayDbSubmission/KCReplayDbQuestSubmission/KCReplayDbQuestSubmissionService.cs
@@ -15,56 +15,14 @@ public class KCReplayDbQuestSubmissionService(
 	private Action<Exception> LogError { get; } = logError;
 
 	private dynamic? LastRawQuestList { get; set; }
-	private int? CompletedQuestId { get; set; }
-	private List<int>? OldQuestIds { get; set; }
+	private List<int> OldQuestIds { get; set; } = [];
 	private List<int>? NewQuestIds { get; set; }
-	private List<JsonNode>? OldQuestList { get; set; }
+	private List<JsonNode> OldQuestList { get; set; } = [];
 	private List<JsonNode>? NewQuestList { get; set; }
-
-	private void ClearState()
-	{
-		CompletedQuestId = null;
-		OldQuestIds = null;
-		NewQuestIds = null;
-		OldQuestList = null;
-		NewQuestList = null;
-	}
-
-	public void ApiReqQuest_ClearItemGetOnRequestReceived(string apiName, dynamic data)
-	{
-		if (LastRawQuestList is null) return;
-
-		ClearState();
-
-		try
-		{
-			CompletedQuestId = int.Parse(data["api_quest_id"]);
-
-			OldQuestList = QuestsFromRawList((string)LastRawQuestList.ToString());
-
-			OldQuestIds = OldQuestList
-				?.Select(n => n["api_no"])
-				.Select(n => n?.GetValueKind() switch
-				{
-					JsonValueKind.Number => n.GetValue<int>(),
-					_ => (int?)null,
-				})
-				.OfType<int>()
-				.Where(i => i != CompletedQuestId)
-				.ToList();
-		}
-		catch (Exception e)
-		{
-			LogError(e);
-			ClearState();
-		}
-	}
 
 	public void ApiGetMember_QuestListOnResponseReceived(string apiName, dynamic data)
 	{
 		LastRawQuestList = data;
-
-		if (CompletedQuestId is null) return;
 
 		try
 		{
@@ -85,17 +43,13 @@ public class KCReplayDbQuestSubmissionService(
 		catch (Exception e)
 		{
 			LogError(e);
-			ClearState();
 		}
 	}
 
 	private void SubmitData()
 	{
-		if (OldQuestIds is null) return;
 		if (NewQuestIds is null) return;
-		if (OldQuestList is null) return;
 		if (NewQuestList is null) return;
-		if (CompletedQuestId is not int completedQuestId) return;
 
 		try
 		{
@@ -105,11 +59,8 @@ public class KCReplayDbQuestSubmissionService(
 
 			if (newlyUnlockedQuestIds.Count is 0)
 			{
-				ClearState();
 				return;
 			}
-
-			List<int> questDataIds = [completedQuestId, .. newlyUnlockedQuestIds];
 
 			List<JsonNode> newQuestData = OldQuestList
 				.Concat(NewQuestList)
@@ -121,11 +72,14 @@ public class KCReplayDbQuestSubmissionService(
 				.DistinctBy(t => t.ApiNo)
 				.Where(t => t.ApiNo switch
 				{
-					int apiNo => questDataIds.Contains(apiNo),
+					int apiNo => newlyUnlockedQuestIds.Contains(apiNo),
 					_ => false,
 				})
 				.Select(t => t.Node)
 				.ToList();
+
+			OldQuestIds.AddRange(NewQuestIds);
+			OldQuestList.AddRange(NewQuestList);
 
 			KCReplayDbQuestSubmissionData submissionData = new()
 			{
@@ -147,7 +101,6 @@ public class KCReplayDbQuestSubmissionService(
 		catch (Exception e)
 		{
 			LogError(e);
-			ClearState();
 		}
 	}
 

--- a/ElectronicObserver/Data/KCReplayDbSubmission/KCReplayDbSubmissionService.cs
+++ b/ElectronicObserver/Data/KCReplayDbSubmission/KCReplayDbSubmissionService.cs
@@ -55,7 +55,6 @@ public class KCReplayDbSubmissionService
 	{
 		KCReplayDbQuestSubmissionService questSubmissionService = new(httpClient, logError);
 
-		APIObserver.Instance.ApiReqQuest_ClearItemGet.RequestReceived += questSubmissionService.ApiReqQuest_ClearItemGetOnRequestReceived;
 		APIObserver.Instance.ApiGetMember_QuestList.ResponseReceived += questSubmissionService.ApiGetMember_QuestListOnResponseReceived;
 
 		return questSubmissionService;
@@ -63,7 +62,6 @@ public class KCReplayDbSubmissionService
 
 	private static void UnsubscribeFromQuestApis(KCReplayDbQuestSubmissionService questSubmissionService)
 	{
-		APIObserver.Instance.ApiReqQuest_ClearItemGet.RequestReceived -= questSubmissionService.ApiReqQuest_ClearItemGetOnRequestReceived;
 		APIObserver.Instance.ApiGetMember_QuestList.ResponseReceived -= questSubmissionService.ApiGetMember_QuestListOnResponseReceived;
 	}
 

--- a/ElectronicObserver/Window/Wpf/Quest/QuestViewModel.cs
+++ b/ElectronicObserver/Window/Wpf/Quest/QuestViewModel.cs
@@ -4,6 +4,7 @@ using System.Collections.ObjectModel;
 using System.ComponentModel;
 using System.Diagnostics;
 using System.Linq;
+using System.Text;
 using System.Windows.Controls;
 using System.Windows.Data;
 using System.Windows.Forms;
@@ -420,17 +421,21 @@ public partial class QuestViewModel : AnchorableViewModel
 					row.QuestView_NameToolTip += $"\r\n{tracker?.GroupConditions.Display}";
 				}
 
-				row.QuestView_NameToolTipExtra = "";
+				StringBuilder toolTipExtra = new(); 
 
 				if (q.Type != 1 && q.GetProgressResetType() is QuestResetType.Daily)
 				{
-					row.QuestView_NameToolTipExtra += $"{FormQuest.QuestView_ProgressResetsDaily}";
+					toolTipExtra.AppendLine();
+					toolTipExtra.Append(FormQuest.QuestView_ProgressResetsDaily);
 				}
 
 				if (q.GetEndDateTime() is DateTime endTime)
 				{
-					row.QuestView_NameToolTipExtra += string.Format(FormQuest.QuestView_EndsOn, endTime);
+					toolTipExtra.AppendLine();
+					toolTipExtra.AppendFormat(FormQuest.QuestView_EndsOn, endTime);
 				}
+
+				row.QuestView_NameToolTipExtra = toolTipExtra.ToString();
 
 				if (row.QuestView_NameToolTipExtra?.Length > 0)
 				{


### PR DESCRIPTION
Before : only submit quest data when a quest is cleared, and it only sends the data of unlocked quests
After : submits full quest list on first load, then only submit diffs