### PR TITLE
Keep UI blocker out of Alt+Tab

### DIFF
--- a/ElectronicObserver/Window/Dialog/UiBlocker/UiBlockerOverlayWindow.xaml
+++ b/ElectronicObserver/Window/Dialog/UiBlocker/UiBlockerOverlayWindow.xaml
@@ -10,7 +10,6 @@
 	AllowsTransparency="True"
 	Background="Transparent"
 	ShowInTaskbar="False"
-	Topmost="True"
 	WindowStyle="None"
 	mc:Ignorable="d"
 	>

--- a/ElectronicObserver/Window/Dialog/UiBlocker/UiBlockerOverlayWindow.xaml.cs
+++ b/ElectronicObserver/Window/Dialog/UiBlocker/UiBlockerOverlayWindow.xaml.cs
@@ -103,6 +103,12 @@ public partial class UiBlockerOverlayWindow
 
 	protected override void OnClosed(EventArgs e)
 	{
+		// Detach the view model handler before the overlay is recreated for another host window.
+		if (DataContext is UiBlockerViewModel viewModel)
+		{
+			viewModel.PropertyChanged -= UpdatePosition;
+		}
+
 		MouseHook?.Dispose();
 		IsVisibleChanged -= OverlayIsVisibleChanged;
 		base.OnClosed(e);

--- a/ElectronicObserver/Window/Dialog/UiBlocker/UiBlockerService.cs
+++ b/ElectronicObserver/Window/Dialog/UiBlocker/UiBlockerService.cs
@@ -24,6 +24,7 @@ public class UiBlockerService(DockingManager dockingManager, Configuration.Confi
 	public void ShowBlocker(UiBlockerViewModel uiBlockerViewModel)
 	{
 		if (GetBrowserControl(DockingManager) is not LayoutDocumentControl anchorableControl) return;
+		if (GetBrowserWindow(anchorableControl) is not System.Windows.Window browserWindow) return;
 
 		Point topLeft = anchorableControl.PointToScreen(new Point(0, 0));
 		Size anchorableSize = new(anchorableControl.ActualWidth, anchorableControl.ActualHeight);
@@ -41,11 +42,8 @@ public class UiBlockerService(DockingManager dockingManager, Configuration.Confi
 
 		uiBlockerViewModel.UpdateBrowserData(zoomRate, browserTop, browserLeft);
 
-		if (!Overlays.TryGetValue(uiBlockerViewModel, out UiBlockerOverlayWindow? overlayWindow))
-		{
-			overlayWindow = new(uiBlockerViewModel);
-			Overlays[uiBlockerViewModel] = overlayWindow;
-		}
+		// Recreate the overlay when the browser moves to a different host window.
+		UiBlockerOverlayWindow overlayWindow = GetOrCreateOverlay(uiBlockerViewModel, browserWindow);
 
 		overlayWindow.Show();
 	}
@@ -87,6 +85,46 @@ public class UiBlockerService(DockingManager dockingManager, Configuration.Confi
 			.TryFindParent<LayoutDocumentControl>();
 
 		return anchorableControl;
+	}
+
+	private static System.Windows.Window? GetBrowserWindow(LayoutDocumentControl browserControl)
+		=> System.Windows.Window.GetWindow(browserControl);
+
+	private UiBlockerOverlayWindow GetOrCreateOverlay(UiBlockerViewModel uiBlockerViewModel, System.Windows.Window browserWindow)
+	{
+		if (!Overlays.TryGetValue(uiBlockerViewModel, out UiBlockerOverlayWindow? overlayWindow))
+		{
+			overlayWindow = CreateOverlay(uiBlockerViewModel, browserWindow);
+			Overlays[uiBlockerViewModel] = overlayWindow;
+			return overlayWindow;
+		}
+
+		if (overlayWindow.Owner == browserWindow) return overlayWindow;
+
+		// Keep the overlay owned by the current browser host so it stays out of Alt+Tab.
+		try
+		{
+			overlayWindow.Close();
+		}
+		catch (InvalidOperationException)
+		{
+			// The previous owner may already have closed the old overlay.
+		}
+
+		overlayWindow = CreateOverlay(uiBlockerViewModel, browserWindow);
+		Overlays[uiBlockerViewModel] = overlayWindow;
+
+		return overlayWindow;
+	}
+
+	private static UiBlockerOverlayWindow CreateOverlay(UiBlockerViewModel uiBlockerViewModel, System.Windows.Window browserWindow)
+	{
+		UiBlockerOverlayWindow overlayWindow = new(uiBlockerViewModel)
+		{
+			Owner = browserWindow,
+		};
+
+		return overlayWindow;
 	}
 
 	private double CalculateZoomRate(Size anchorableSize, int toolbarHeight, int toolbarWidth)


### PR DESCRIPTION
The UI blocker currently uses a standalone topmost window. That makes the blocker appear in the Alt+Tab window list and lets it stay above unrelated applications when the user switches away from Electronic Observer.

This change keeps the existing UI blocker flow and mouse hook behavior, but changes the overlay ownership model. UiBlockerService now resolves the current browser host window and creates the overlay as an owned window for that host. The service also recreates the overlay when the browser moves to another host window, and it tolerates the old overlay already being closed by the previous owner.

The change is limited to the UiBlocker overlay files. The overlay XAML no longer sets a global topmost flag, and the code-behind detaches the view model PropertyChanged handler when the overlay is closed.

The goal is to keep the blocker attached to the browser window, remove it from Alt+Tab, and stop it from covering other applications, without changing the existing trigger timing or blocker placement logic.