### PR TITLE
Update drop record search status

### DIFF
--- a/ElectronicObserver/Window/Dialog/EncycloRes.en.resx
+++ b/ElectronicObserver/Window/Dialog/EncycloRes.en.resx
@@ -336,6 +336,9 @@ Maximum: {2} Steel / {3} Fuel
   <data name="SearchComplete" xml:space="preserve">
     <value>Search complete.</value>
   </data>
+  <data name="SearchCompleteWithRecordAndRowCount" xml:space="preserve">
+    <value>Search complete. {0} records, showing {1} rows</value>
+  </data>
   <data name="Searching" xml:space="preserve">
     <value>Searching</value>
   </data>

--- a/ElectronicObserver/Window/Dialog/EncycloRes.en.resx
+++ b/ElectronicObserver/Window/Dialog/EncycloRes.en.resx
@@ -337,7 +337,7 @@ Maximum: {2} Steel / {3} Fuel
     <value>Search complete.</value>
   </data>
   <data name="SearchCompleteWithRecordAndRowCount" xml:space="preserve">
-    <value>Search complete. {0} records, showing {1} rows</value>
+    <value>Search complete. {0} records, combined into {1} rows</value>
   </data>
   <data name="Searching" xml:space="preserve">
     <value>Searching</value>

--- a/ElectronicObserver/Window/Dialog/EncycloRes.resx
+++ b/ElectronicObserver/Window/Dialog/EncycloRes.resx
@@ -337,7 +337,7 @@ HP1あたり: 鋼 {0:F2} / 燃 {1:F2}
     <value>検索が完了しました。</value>
   </data>
   <data name="SearchCompleteWithRecordAndRowCount" xml:space="preserve">
-    <value>検索が完了しました。全 {0} 件、表示 {1} 行</value>
+    <value>検索が完了しました。全 {0} 件、まとめ後 {1} 行</value>
   </data>
   <data name="Searching" xml:space="preserve">
     <value>検索中です</value>

--- a/ElectronicObserver/Window/Dialog/EncycloRes.resx
+++ b/ElectronicObserver/Window/Dialog/EncycloRes.resx
@@ -336,6 +336,9 @@ HP1あたり: 鋼 {0:F2} / 燃 {1:F2}
   <data name="SearchComplete" xml:space="preserve">
     <value>検索が完了しました。</value>
   </data>
+  <data name="SearchCompleteWithRecordAndRowCount" xml:space="preserve">
+    <value>検索が完了しました。全 {0} 件、表示 {1} 行</value>
+  </data>
   <data name="Searching" xml:space="preserve">
     <value>検索中です</value>
   </data>

--- a/ElectronicObserver/Window/Dialog/EncycloRes.zh-TW.resx
+++ b/ElectronicObserver/Window/Dialog/EncycloRes.zh-TW.resx
@@ -336,6 +336,9 @@
   <data name="SearchComplete" xml:space="preserve">
     <value>搜尋完成。</value>
   </data>
+  <data name="SearchCompleteWithRecordAndRowCount" xml:space="preserve">
+    <value>搜尋完成。共 {0} 筆紀錄，顯示 {1} 列</value>
+  </data>
   <data name="Searching" xml:space="preserve">
     <value>搜尋中</value>
   </data>

--- a/ElectronicObserver/Window/Dialog/EncycloRes.zh-TW.resx
+++ b/ElectronicObserver/Window/Dialog/EncycloRes.zh-TW.resx
@@ -337,7 +337,7 @@
     <value>搜尋完成。</value>
   </data>
   <data name="SearchCompleteWithRecordAndRowCount" xml:space="preserve">
-    <value>搜尋完成。共 {0} 筆紀錄，顯示 {1} 列</value>
+    <value>搜尋完成。共 {0} 筆紀錄，合併 {1} 列</value>
   </data>
   <data name="Searching" xml:space="preserve">
     <value>搜尋中</value>

--- a/ElectronicObserver/Window/Tools/DropRecordViewer/DropRecordViewerViewModel.cs
+++ b/ElectronicObserver/Window/Tools/DropRecordViewer/DropRecordViewerViewModel.cs
@@ -5,6 +5,7 @@ using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Linq;
+using System.ComponentModel;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
@@ -372,6 +373,15 @@ public sealed partial class DropRecordViewerViewModel : WindowViewModelBase
 		return (mapAreaId & 0xFF) << 24 | (mapInfoId & 0xFF) << 16 | (cell & 0xFF) << 8 | (difficulty & 0x7F) << 1 | (isboss ? 1 : 0);
 	}
 
+	private static int CountDisplayedRows(ICollectionView view)
+	{
+		view.Refresh();
+
+		return view is System.Collections.ICollection collection
+			? collection.Count
+			: view.Cast<object>().Count();
+	}
+
 	[RelayCommand(IncludeCancelCommand = true)]
 	private async Task Search(CancellationToken cancellationToken)
 	{
@@ -380,22 +390,31 @@ public sealed partial class DropRecordViewerViewModel : WindowViewModelBase
 
 		try
 		{
+			int recordCount;
+			int displayRowCount;
+
 			if (MergeRows)
 			{
-				IEnumerable<MergedDropRecordRow> rows = await Task.Run(MakeMergedDropRecordRows, cancellationToken);
+				List<MergedDropRecordRow> rows = (await Task.Run(MakeMergedDropRecordRows, cancellationToken)).ToList();
 
 				MergedRecordRows = new(rows);
 				DataGridMergedRowsViewModel.ItemsSource = MergedRecordRows;
+				recordCount = rows.Sum(row => row.Count);
+				displayRowCount = CountDisplayedRows(DataGridMergedRowsViewModel.Items);
 			}
 			else
 			{
-				IEnumerable<DropRecordRow> rows = await Task.Run(MakeDropRecordRows, cancellationToken);
+				List<DropRecordRow> rows = (await Task.Run(MakeDropRecordRows, cancellationToken)).ToList();
 
 				RecordRows = new(rows);
 				DataGridRawRowsViewModel.ItemsSource = RecordRows;
+				recordCount = rows.Count;
+				displayRowCount = CountDisplayedRows(DataGridRawRowsViewModel.Items);
 			}
 
-			StatusInfoText = $"{EncycloRes.SearchComplete} ({(int)(DateTime.UtcNow - SearchStartTime).TotalMilliseconds} ms)";
+			int elapsedMs = (int)(DateTime.UtcNow - SearchStartTime).TotalMilliseconds;
+			StatusInfoText =
+				$"{string.Format(EncycloRes.SearchCompleteWithRecordAndRowCount, recordCount, displayRowCount)} ({elapsedMs} ms)";
 		}
 		catch (OperationCanceledException)
 		{

--- a/ElectronicObserver/Window/Tools/DropRecordViewer/DropRecordViewerViewModel.cs
+++ b/ElectronicObserver/Window/Tools/DropRecordViewer/DropRecordViewerViewModel.cs
@@ -5,7 +5,6 @@ using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Linq;
-using System.ComponentModel;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
@@ -373,15 +372,6 @@ public sealed partial class DropRecordViewerViewModel : WindowViewModelBase
 		return (mapAreaId & 0xFF) << 24 | (mapInfoId & 0xFF) << 16 | (cell & 0xFF) << 8 | (difficulty & 0x7F) << 1 | (isboss ? 1 : 0);
 	}
 
-	private static int CountDisplayedRows(ICollectionView view)
-	{
-		view.Refresh();
-
-		return view is System.Collections.ICollection collection
-			? collection.Count
-			: view.Cast<object>().Count();
-	}
-
 	[RelayCommand(IncludeCancelCommand = true)]
 	private async Task Search(CancellationToken cancellationToken)
 	{
@@ -400,7 +390,7 @@ public sealed partial class DropRecordViewerViewModel : WindowViewModelBase
 				MergedRecordRows = new(rows);
 				DataGridMergedRowsViewModel.ItemsSource = MergedRecordRows;
 				recordCount = rows.Sum(row => row.Count);
-				displayRowCount = CountDisplayedRows(DataGridMergedRowsViewModel.Items);
+				displayRowCount = rows.Count;
 			}
 			else
 			{
@@ -409,7 +399,7 @@ public sealed partial class DropRecordViewerViewModel : WindowViewModelBase
 				RecordRows = new(rows);
 				DataGridRawRowsViewModel.ItemsSource = RecordRows;
 				recordCount = rows.Count;
-				displayRowCount = CountDisplayedRows(DataGridRawRowsViewModel.Items);
+				displayRowCount = rows.Count;
 			}
 
 			int elapsedMs = (int)(DateTime.UtcNow - SearchStartTime).TotalMilliseconds;


### PR DESCRIPTION
Add a dedicated localized status message for drop record searches with record and visible row counts.
Do not change other search viewers or broader record filtering behavior.

<img width="523" height="148" alt="圖片" src="https://github.com/user-attachments/assets/aacbd031-4593-4608-992c-16f0d13c8044" />
