### PR TITLE
Split spoiler log settings

### DIFF
--- a/ElectronicObserver/Data/Battle/BattleManager.cs
+++ b/ElectronicObserver/Data/Battle/BattleManager.cs
@@ -509,7 +509,8 @@ public class BattleManager : APIWrapper
 			int shipID = Result.DroppedShipID;
 			int itemID = Result.DroppedItemID;
 			int eqID = Result.DroppedEquipmentID;
-			bool showLog = Utility.Configuration.Config.Log.ShowSpoiler;
+			bool showLog = Utility.Configuration.Config.Log.ShowSpoiler &&
+				Utility.Configuration.Config.Log.ShowDropSpoiler;
 
 			if (shipID != -1)
 			{

--- a/ElectronicObserver/Observer/kcsapi/api_req_kaisou/powerup.cs
+++ b/ElectronicObserver/Observer/kcsapi/api_req_kaisou/powerup.cs
@@ -64,7 +64,8 @@ public class powerup : APIBase
 		if (ship != null)
 		{
 
-			if (Utility.Configuration.Config.Log.ShowSpoiler)
+			if (Utility.Configuration.Config.Log.ShowSpoiler &&
+				Utility.Configuration.Config.Log.ShowModernizationSpoiler)
 			{
 				if ((int)data.api_powerup_flag == 0)
 				{

--- a/ElectronicObserver/Observer/kcsapi/api_req_kousyou/createitem.cs
+++ b/ElectronicObserver/Observer/kcsapi/api_req_kousyou/createitem.cs
@@ -23,7 +23,8 @@ public class createitem : APIBase
 
 
 		//logging
-		if (Utility.Configuration.Config.Log.ShowSpoiler)
+		if (Utility.Configuration.Config.Log.ShowSpoiler &&
+			Utility.Configuration.Config.Log.ShowDevelopmentSpoiler)
 		{
 			//Utility.Logger.Add(2, $"開発結果: {string.Join(", ", dev.Results)} ({dev.Fuel}/{dev.Ammo}/{dev.Steel}/{dev.Bauxite} 秘書艦: {db.Fleet[1].MembersInstance[0].NameWithLevel})");
 

--- a/ElectronicObserver/Observer/kcsapi/api_req_kousyou/remodel_slot.cs
+++ b/ElectronicObserver/Observer/kcsapi/api_req_kousyou/remodel_slot.cs
@@ -33,12 +33,14 @@ public class remodel_slot : APIBase
 			{
 				eq.LoadFromResponse(APIName, data.api_after_slot);
 
-				if (Utility.Configuration.Config.Log.ShowSpoiler)
+				if (Utility.Configuration.Config.Log.ShowSpoiler &&
+					Utility.Configuration.Config.Log.ShowEquipmentImprovementSpoiler)
 					Utility.Logger.Add(2, string.Format(LoggerRes.ImprovedEqSuccess, eq.NameWithLevel));
 			}
 
 		}
-		else if (Utility.Configuration.Config.Log.ShowSpoiler)
+		else if (Utility.Configuration.Config.Log.ShowSpoiler &&
+			Utility.Configuration.Config.Log.ShowEquipmentImprovementSpoiler)
 		{
 			Utility.Logger.Add(2, string.Format(LoggerRes.ImprovedFailure, db.Equipments[_equipmentID].NameWithLevel));
 		}

--- a/ElectronicObserver/Observer/kcsapi/api_req_mission/result.cs
+++ b/ElectronicObserver/Observer/kcsapi/api_req_mission/result.cs
@@ -34,7 +34,8 @@ public class result : APIBase
 
 
 		// 獲得資源表示
-		if (Utility.Configuration.Config.Log.ShowSpoiler)
+		if (Utility.Configuration.Config.Log.ShowSpoiler &&
+			Utility.Configuration.Config.Log.ShowExpeditionSpoiler)
 		{
 
 			var sb = new LinkedList<string>();

--- a/ElectronicObserver/Properties/Window/Dialog/ConfigurationResources.en.resx
+++ b/ElectronicObserver/Properties/Window/Dialog/ConfigurationResources.en.resx
@@ -213,6 +213,42 @@ Battle histories are saved in the BattleLog subfolder.</value>
     <value>Show developed items and dropped ships in the log.
 Disable this setting to hide the information.</value>
   </data>
+  <data name="Log_ShowDropSpoiler" xml:space="preserve">
+    <value>Show drop reports</value>
+  </data>
+  <data name="Log_ShowDropSpoilerToolTip" xml:space="preserve">
+    <value>Record dropped ships, items, and equipment in the log.</value>
+  </data>
+  <data name="Log_ShowExpeditionSpoiler" xml:space="preserve">
+    <value>Show expedition rewards</value>
+  </data>
+  <data name="Log_ShowExpeditionSpoilerToolTip" xml:space="preserve">
+    <value>Record resources and items gained from expeditions in the log.</value>
+  </data>
+  <data name="Log_ShowDevelopmentSpoiler" xml:space="preserve">
+    <value>Show development results</value>
+  </data>
+  <data name="Log_ShowDevelopmentSpoilerToolTip" xml:space="preserve">
+    <value>Record developed equipment names and recipes in the log.</value>
+  </data>
+  <data name="Log_ShowEquipmentImprovementSpoiler" xml:space="preserve">
+    <value>Show equipment improvement results</value>
+  </data>
+  <data name="Log_ShowEquipmentImprovementSpoilerToolTip" xml:space="preserve">
+    <value>Record equipment improvement success or failure in the log.</value>
+  </data>
+  <data name="Log_ShowModernizationSpoiler" xml:space="preserve">
+    <value>Show modernization results</value>
+  </data>
+  <data name="Log_ShowModernizationSpoilerToolTip" xml:space="preserve">
+    <value>Record modernization success or failure and stat gains in the log.</value>
+  </data>
+  <data name="Log_ShowConstructionSpoiler" xml:space="preserve">
+    <value>Show constructed ship names</value>
+  </data>
+  <data name="Log_ShowConstructionSpoilerToolTip" xml:space="preserve">
+    <value>Show the actual ship name in construction completion logs.</value>
+  </data>
   <data name="Log_LogLevelToolTip" xml:space="preserve">
     <value>Specify logging level for the program. Smaller number means more verbose logging.
 1: Debug

--- a/ElectronicObserver/Properties/Window/Dialog/ConfigurationResources.resx
+++ b/ElectronicObserver/Properties/Window/Dialog/ConfigurationResources.resx
@@ -215,6 +215,42 @@
     <value>開発したアイテム名やドロップ艦名などのログを記録するかを指定します。
 先にわかってしまうことが気になる方は無効にしてください。</value>
   </data>
+  <data name="Log_ShowDropSpoiler" xml:space="preserve">
+    <value>ドロップ報告を表示</value>
+  </data>
+  <data name="Log_ShowDropSpoilerToolTip" xml:space="preserve">
+    <value>ドロップした艦娘、アイテム、装備をログに記録するかを指定します。</value>
+  </data>
+  <data name="Log_ShowExpeditionSpoiler" xml:space="preserve">
+    <value>遠征報酬を表示</value>
+  </data>
+  <data name="Log_ShowExpeditionSpoilerToolTip" xml:space="preserve">
+    <value>遠征で獲得した資源やアイテムをログに記録するかを指定します。</value>
+  </data>
+  <data name="Log_ShowDevelopmentSpoiler" xml:space="preserve">
+    <value>開発結果を表示</value>
+  </data>
+  <data name="Log_ShowDevelopmentSpoilerToolTip" xml:space="preserve">
+    <value>開発した装備名と開発レシピをログに記録するかを指定します。</value>
+  </data>
+  <data name="Log_ShowEquipmentImprovementSpoiler" xml:space="preserve">
+    <value>装備改修結果を表示</value>
+  </data>
+  <data name="Log_ShowEquipmentImprovementSpoilerToolTip" xml:space="preserve">
+    <value>装備改修の成功または失敗をログに記録するかを指定します。</value>
+  </data>
+  <data name="Log_ShowModernizationSpoiler" xml:space="preserve">
+    <value>近代化改修結果を表示</value>
+  </data>
+  <data name="Log_ShowModernizationSpoilerToolTip" xml:space="preserve">
+    <value>近代化改修の成功または失敗と上昇値をログに記録するかを指定します。</value>
+  </data>
+  <data name="Log_ShowConstructionSpoiler" xml:space="preserve">
+    <value>建造艦名を表示</value>
+  </data>
+  <data name="Log_ShowConstructionSpoilerToolTip" xml:space="preserve">
+    <value>建造完了ログに実際の艦娘名を表示するかを指定します。</value>
+  </data>
   <data name="Log_LogLevelToolTip" xml:space="preserve">
     <value>小さい値では詳細なログを、大きな値では重要なログのみを表示します。
 1: デバッグレベル

--- a/ElectronicObserver/Properties/Window/Dialog/ConfigurationResources.zh-TW.resx
+++ b/ElectronicObserver/Properties/Window/Dialog/ConfigurationResources.zh-TW.resx
@@ -215,6 +215,42 @@
     <value>在日誌中顯示已開發的物品和掉落的船隻。
 禁用此設定可隱藏訊息。</value>
   </data>
+  <data name="Log_ShowDropSpoiler" xml:space="preserve">
+    <value>顯示掉落報告</value>
+  </data>
+  <data name="Log_ShowDropSpoilerToolTip" xml:space="preserve">
+    <value>指定是否將掉落艦娘、道具與裝備記錄到日誌。</value>
+  </data>
+  <data name="Log_ShowExpeditionSpoiler" xml:space="preserve">
+    <value>顯示遠征獎勵</value>
+  </data>
+  <data name="Log_ShowExpeditionSpoilerToolTip" xml:space="preserve">
+    <value>指定是否將遠征取得的資源與道具記錄到日誌。</value>
+  </data>
+  <data name="Log_ShowDevelopmentSpoiler" xml:space="preserve">
+    <value>顯示開發結果</value>
+  </data>
+  <data name="Log_ShowDevelopmentSpoilerToolTip" xml:space="preserve">
+    <value>指定是否將開發出的裝備名稱與開發配方記錄到日誌。</value>
+  </data>
+  <data name="Log_ShowEquipmentImprovementSpoiler" xml:space="preserve">
+    <value>顯示裝備改修結果</value>
+  </data>
+  <data name="Log_ShowEquipmentImprovementSpoilerToolTip" xml:space="preserve">
+    <value>指定是否將裝備改修成功或失敗記錄到日誌。</value>
+  </data>
+  <data name="Log_ShowModernizationSpoiler" xml:space="preserve">
+    <value>顯示近代化改修結果</value>
+  </data>
+  <data name="Log_ShowModernizationSpoilerToolTip" xml:space="preserve">
+    <value>指定是否將近代化改修成功或失敗與提升數值記錄到日誌。</value>
+  </data>
+  <data name="Log_ShowConstructionSpoiler" xml:space="preserve">
+    <value>顯示建造艦名</value>
+  </data>
+  <data name="Log_ShowConstructionSpoilerToolTip" xml:space="preserve">
+    <value>指定是否在建造完成日誌中顯示實際艦娘名稱。</value>
+  </data>
   <data name="Log_LogLevelToolTip" xml:space="preserve">
     <value>指定程式的日誌記錄級別。較小的數字意味著更詳細的日誌記錄。
 1：除錯級別

--- a/ElectronicObserver/Utility/Configuration.cs
+++ b/ElectronicObserver/Utility/Configuration.cs
@@ -595,6 +595,18 @@ public sealed class Configuration
 			/// </summary>
 			public bool ShowSpoiler { get; set; }
 
+			public bool ShowDropSpoiler { get; set; }
+
+			public bool ShowExpeditionSpoiler { get; set; }
+
+			public bool ShowDevelopmentSpoiler { get; set; }
+
+			public bool ShowEquipmentImprovementSpoiler { get; set; }
+
+			public bool ShowModernizationSpoiler { get; set; }
+
+			public bool ShowConstructionSpoiler { get; set; }
+
 			/// <summary>
 			/// プレイ時間
 			/// </summary>
@@ -623,6 +635,12 @@ public sealed class Configuration
 				SaveErrorReport = true;
 				FileEncodingID = 4;
 				ShowSpoiler = true;
+				ShowDropSpoiler = true;
+				ShowExpeditionSpoiler = true;
+				ShowDevelopmentSpoiler = true;
+				ShowEquipmentImprovementSpoiler = true;
+				ShowModernizationSpoiler = true;
+				ShowConstructionSpoiler = true;
 				PlayTime = 0;
 				PlayTimeIgnoreInterval = 10 * 60;
 				SaveBattleLog = false;

--- a/ElectronicObserver/Window/Settings/Log/ConfigurationLogTranslationViewModel.cs
+++ b/ElectronicObserver/Window/Settings/Log/ConfigurationLogTranslationViewModel.cs
@@ -12,6 +12,18 @@ public class ConfigurationLogTranslationViewModel : TranslationBaseViewModel
 	public string Log_LogLevelToolTip => ConfigurationResources.Log_LogLevelToolTip;
 	public string Log_ShowSpoiler => ConfigurationResources.Log_ShowSpoiler;
 	public string Log_ShowSpoilerToolTip => ConfigurationResources.Log_ShowSpoilerToolTip;
+	public string Log_ShowDropSpoiler => ConfigurationResources.Log_ShowDropSpoiler;
+	public string Log_ShowDropSpoilerToolTip => ConfigurationResources.Log_ShowDropSpoilerToolTip;
+	public string Log_ShowExpeditionSpoiler => ConfigurationResources.Log_ShowExpeditionSpoiler;
+	public string Log_ShowExpeditionSpoilerToolTip => ConfigurationResources.Log_ShowExpeditionSpoilerToolTip;
+	public string Log_ShowDevelopmentSpoiler => ConfigurationResources.Log_ShowDevelopmentSpoiler;
+	public string Log_ShowDevelopmentSpoilerToolTip => ConfigurationResources.Log_ShowDevelopmentSpoilerToolTip;
+	public string Log_ShowEquipmentImprovementSpoiler => ConfigurationResources.Log_ShowEquipmentImprovementSpoiler;
+	public string Log_ShowEquipmentImprovementSpoilerToolTip => ConfigurationResources.Log_ShowEquipmentImprovementSpoilerToolTip;
+	public string Log_ShowModernizationSpoiler => ConfigurationResources.Log_ShowModernizationSpoiler;
+	public string Log_ShowModernizationSpoilerToolTip => ConfigurationResources.Log_ShowModernizationSpoilerToolTip;
+	public string Log_ShowConstructionSpoiler => ConfigurationResources.Log_ShowConstructionSpoiler;
+	public string Log_ShowConstructionSpoilerToolTip => ConfigurationResources.Log_ShowConstructionSpoilerToolTip;
 
 	public string Log_SaveErrorReport => ConfigRes.SaveErrorReport;
 	public string SaveErrorToolTip => ConfigRes.SaveErrorHint;

--- a/ElectronicObserver/Window/Settings/Log/ConfigurationLogUserControl.xaml
+++ b/ElectronicObserver/Window/Settings/Log/ConfigurationLogUserControl.xaml
@@ -29,11 +29,56 @@
 				SpinButtonPlacementMode="Inline"
 				Value="{Binding LogLevel}"
 				/>
+		</StackPanel>
+
+		<StackPanel HorizontalAlignment="Left">
 			<CheckBox
+				x:Name="ShowSpoilerCheckBox"
 				Content="{Binding Translation.Log_ShowSpoiler}"
 				IsChecked="{Binding ShowSpoiler}"
 				ToolTip="{Binding Translation.Log_ShowSpoilerToolTip}"
 				/>
+			<Border
+				HorizontalAlignment="Left"
+				Margin="0 4 0 0"
+				Padding="8"
+				BorderBrush="DarkGray"
+				BorderThickness="1"
+				CornerRadius="2"
+				>
+				<StackPanel Margin="16 0 0 0" IsEnabled="{Binding IsChecked, ElementName=ShowSpoilerCheckBox}">
+					<CheckBox
+						Content="{Binding Translation.Log_ShowDropSpoiler}"
+						IsChecked="{Binding ShowDropSpoiler}"
+						ToolTip="{Binding Translation.Log_ShowDropSpoilerToolTip}"
+						/>
+					<CheckBox
+						Content="{Binding Translation.Log_ShowExpeditionSpoiler}"
+						IsChecked="{Binding ShowExpeditionSpoiler}"
+						ToolTip="{Binding Translation.Log_ShowExpeditionSpoilerToolTip}"
+						/>
+					<CheckBox
+						Content="{Binding Translation.Log_ShowDevelopmentSpoiler}"
+						IsChecked="{Binding ShowDevelopmentSpoiler}"
+						ToolTip="{Binding Translation.Log_ShowDevelopmentSpoilerToolTip}"
+						/>
+					<CheckBox
+						Content="{Binding Translation.Log_ShowEquipmentImprovementSpoiler}"
+						IsChecked="{Binding ShowEquipmentImprovementSpoiler}"
+						ToolTip="{Binding Translation.Log_ShowEquipmentImprovementSpoilerToolTip}"
+						/>
+					<CheckBox
+						Content="{Binding Translation.Log_ShowModernizationSpoiler}"
+						IsChecked="{Binding ShowModernizationSpoiler}"
+						ToolTip="{Binding Translation.Log_ShowModernizationSpoilerToolTip}"
+						/>
+					<CheckBox
+						Content="{Binding Translation.Log_ShowConstructionSpoiler}"
+						IsChecked="{Binding ShowConstructionSpoiler}"
+						ToolTip="{Binding Translation.Log_ShowConstructionSpoilerToolTip}"
+						/>
+				</StackPanel>
+			</Border>
 		</StackPanel>
 
 		<CheckBox

--- a/ElectronicObserver/Window/Settings/Log/ConfigurationLogViewModel.cs
+++ b/ElectronicObserver/Window/Settings/Log/ConfigurationLogViewModel.cs
@@ -22,6 +22,18 @@ public class ConfigurationLogViewModel : ConfigurationViewModelBase
 
 	public bool ShowSpoiler { get; set; }
 
+	public bool ShowDropSpoiler { get; set; }
+
+	public bool ShowExpeditionSpoiler { get; set; }
+
+	public bool ShowDevelopmentSpoiler { get; set; }
+
+	public bool ShowEquipmentImprovementSpoiler { get; set; }
+
+	public bool ShowModernizationSpoiler { get; set; }
+
+	public bool ShowConstructionSpoiler { get; set; }
+
 	public bool SaveBattleLog { get; set; }
 
 	public bool SaveLogImmediately { get; set; }
@@ -50,6 +62,12 @@ public class ConfigurationLogViewModel : ConfigurationViewModelBase
 		SaveLogFlag = config.SaveLogFlag;
 		SaveErrorReport = config.SaveErrorReport;
 		ShowSpoiler = config.ShowSpoiler;
+		ShowDropSpoiler = config.ShowDropSpoiler;
+		ShowExpeditionSpoiler = config.ShowExpeditionSpoiler;
+		ShowDevelopmentSpoiler = config.ShowDevelopmentSpoiler;
+		ShowEquipmentImprovementSpoiler = config.ShowEquipmentImprovementSpoiler;
+		ShowModernizationSpoiler = config.ShowModernizationSpoiler;
+		ShowConstructionSpoiler = config.ShowConstructionSpoiler;
 		SaveBattleLog = config.SaveBattleLog;
 		SaveLogImmediately = config.SaveLogImmediately;
 		SelectedEncoding = Encodings
@@ -64,6 +82,12 @@ public class ConfigurationLogViewModel : ConfigurationViewModelBase
 		Config.SaveErrorReport = SaveErrorReport;
 		Config.FileEncodingID = SelectedEncoding.Value;
 		Config.ShowSpoiler = ShowSpoiler;
+		Config.ShowDropSpoiler = ShowDropSpoiler;
+		Config.ShowExpeditionSpoiler = ShowExpeditionSpoiler;
+		Config.ShowDevelopmentSpoiler = ShowDevelopmentSpoiler;
+		Config.ShowEquipmentImprovementSpoiler = ShowEquipmentImprovementSpoiler;
+		Config.ShowModernizationSpoiler = ShowModernizationSpoiler;
+		Config.ShowConstructionSpoiler = ShowConstructionSpoiler;
 		Config.SaveBattleLog = SaveBattleLog;
 		Config.SaveLogImmediately = SaveLogImmediately;
 	}

--- a/ElectronicObserver/Window/Wpf/Arsenal/ArsenalViewModel.cs
+++ b/ElectronicObserver/Window/Wpf/Arsenal/ArsenalViewModel.cs
@@ -62,7 +62,9 @@ public class ArsenalViewModel : AnchorableViewModel
 			ArsenalData arsenal = KCDatabase.Instance.Arsenals[BuildingId];
 			IShipDataMaster ship = KCDatabase.Instance.MasterShips[arsenal.ShipID];
 
-			string name = (Configuration.Config.Log.ShowSpoiler && Configuration.Config.FormArsenal.ShowShipName) switch
+			string name = (Configuration.Config.Log.ShowSpoiler &&
+				Configuration.Config.Log.ShowConstructionSpoiler &&
+				Configuration.Config.FormArsenal.ShowShipName) switch
 			{
 				true => $"{ship.ShipTypeName} {ship.NameWithClass}",
 				_ => GeneralRes.ShipGirl,


### PR DESCRIPTION
Solved #285. Add granular spoiler settings under the existing log spoiler switch.

The global ShowSpoiler setting remains the top-level guard, while individual settings now control drop logs, expedition rewards, development results, equipment improvement results, modernization results, and construction ship names.

Update the log settings UI to group spoiler options together.