### PR TITLE
Fix TsunDb drop report when you have capped slots #668

### DIFF
--- a/ElectronicObserver/Data/AdmiralData.cs
+++ b/ElectronicObserver/Data/AdmiralData.cs
@@ -1,9 +1,9 @@
 ﻿using System;
-using System.Linq;
 using System.Collections.Generic;
+using System.Linq;
 using ElectronicObserver.Core;
-using static ElectronicObserver.Data.Constants;
 using ElectronicObserver.Core.Types.Extensions;
+using static ElectronicObserver.Data.Constants;
 
 namespace ElectronicObserver.Data;
 

--- a/ElectronicObserver/Data/AdmiralData.cs
+++ b/ElectronicObserver/Data/AdmiralData.cs
@@ -171,7 +171,7 @@ public class AdmiralData : APIWrapper
 	{
 		get
 		{
-			int equipmentCount = KCDatabase.Instance.Equipments.Values.Count(e => e.MasterEquipment.UsesSlotSpace());
+			int equipmentCount = KCDatabase.Instance.Equipments.Values.Count(e => e?.MasterEquipment.UsesSlotSpace() is true);
 
 			if (KCDatabase.Instance.Battle != null)
 			{

--- a/ElectronicObserver/Data/AdmiralData.cs
+++ b/ElectronicObserver/Data/AdmiralData.cs
@@ -1,8 +1,9 @@
 ﻿using System;
+using System.Linq;
 using System.Collections.Generic;
 using ElectronicObserver.Core;
-using ElectronicObserver.Utility.Mathematics;
 using static ElectronicObserver.Data.Constants;
+using ElectronicObserver.Core.Types.Extensions;
 
 namespace ElectronicObserver.Data;
 
@@ -150,6 +151,34 @@ public class AdmiralData : APIWrapper
 		{
 			if (RawData != null)
 				RawData.api_comment = data["api_cmt"];
+		}
+	}
+
+	public int RealShipCount
+	{
+		get
+		{
+			if (KCDatabase.Instance.Battle != null)
+			{
+				return KCDatabase.Instance.Ships.Count + KCDatabase.Instance.Battle.DroppedShipCount;
+			}
+
+			return KCDatabase.Instance.Ships.Count;
+		}
+	}
+
+	public int RealEquipmentCount
+	{
+		get
+		{
+			int equipmentCount = KCDatabase.Instance.Equipments.Values.Count(e => e.MasterEquipment.UsesSlotSpace());
+
+			if (KCDatabase.Instance.Battle != null)
+			{
+				return equipmentCount + KCDatabase.Instance.Battle.DroppedEquipmentCount;
+			}
+
+			return equipmentCount;
 		}
 	}
 }

--- a/ElectronicObserver/Data/TsunDbSubmission/TsunDbSubmissionManager.cs
+++ b/ElectronicObserver/Data/TsunDbSubmission/TsunDbSubmissionManager.cs
@@ -1,9 +1,5 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
 using DynaJson;
-using ElectronicObserver.Core.Types;
-using ElectronicObserver.Core.Types.Extensions;
 using ElectronicObserver.Data.TsunDbSubmission.Battle;
 using ElectronicObserver.Utility;
 

--- a/ElectronicObserver/Data/TsunDbSubmission/TsunDbSubmissionManager.cs
+++ b/ElectronicObserver/Data/TsunDbSubmission/TsunDbSubmissionManager.cs
@@ -1,6 +1,8 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using DynaJson;
+using ElectronicObserver.Core.Types;
 using ElectronicObserver.Core.Types.Extensions;
 using ElectronicObserver.Data.TsunDbSubmission.Battle;
 using ElectronicObserver.Utility;
@@ -47,11 +49,12 @@ public class TsunDbSubmissionManager : ResponseWrapper
 			{
 				case "api_req_sortie/battleresult":
 				case "api_req_combined_battle/battleresult":
-					if (db.Ships.Count < db.Admiral.MaxShipCount && (db.Equipments.Values.Count(e => e.MasterEquipment.UsesSlotSpace()) < db.Admiral.MaxEquipmentCount))
+					if (CanReportDrop(db))
 					{
 						new ShipDrop(data).SendData();
 						new ShipDropLoc(data).SendData();
 					}
+
 					break;
 				case "api_req_map/start":
 				{
@@ -117,5 +120,15 @@ public class TsunDbSubmissionManager : ResponseWrapper
 		{
 			ErrorReporter.SendErrorReport(ex, "TsunDb Submission module");
 		}
+	}
+
+	private static bool CanReportDrop(KCDatabase db)
+	{
+		if (db.Battle.Result.DroppedShipID > 0) return true;
+
+		if (db.Admiral.RealShipCount >= db.Admiral.MaxShipCount) return false;
+		if (db.Admiral.RealEquipmentCount >= db.Admiral.MaxEquipmentCount - 3) return false;
+
+		return true;
 	}
 }

--- a/ElectronicObserver/Window/Wpf/Headquarters/HeadquartersViewModel.cs
+++ b/ElectronicObserver/Window/Wpf/Headquarters/HeadquartersViewModel.cs
@@ -6,7 +6,6 @@ using System.Windows;
 using System.Windows.Media;
 using CommunityToolkit.Mvvm.DependencyInjection;
 using CommunityToolkit.Mvvm.Input;
-using ElectronicObserver.Core.Types.Extensions;
 using ElectronicObserver.Data;
 using ElectronicObserver.Observer;
 using ElectronicObserver.Resource;

--- a/ElectronicObserver/Window/Wpf/Headquarters/HeadquartersViewModel.cs
+++ b/ElectronicObserver/Window/Wpf/Headquarters/HeadquartersViewModel.cs
@@ -296,8 +296,8 @@ public partial class HeadquartersViewModel : AnchorableViewModel
 		// FlowPanelFleet.SuspendLayout();
 		{
 
-			ShipCount.Text = string.Format("{0}/{1}", RealShipCount, db.Admiral.MaxShipCount);
-			if (RealShipCount > db.Admiral.MaxShipCount - 5)
+			ShipCount.Text = string.Format("{0}/{1}", db.Admiral.RealShipCount, db.Admiral.MaxShipCount);
+			if (db.Admiral.RealShipCount > db.Admiral.MaxShipCount - 5)
 			{
 				ShipCount.BackColor = Utility.Configuration.Config.UI.Headquarters_ShipCountOverBG;
 				ShipCount.ForeColor = Utility.Configuration.Config.UI.Headquarters_ShipCountOverFG;
@@ -307,10 +307,10 @@ public partial class HeadquartersViewModel : AnchorableViewModel
 				ShipCount.BackColor = System.Drawing.Color.Transparent;
 				ShipCount.ForeColor = Utility.Configuration.Config.UI.ForeColor;
 			}
-			ShipCount.Tag = RealShipCount >= db.Admiral.MaxShipCount;
+			ShipCount.Tag = db.Admiral.RealShipCount >= db.Admiral.MaxShipCount;
 
-			EquipmentCount.Text = string.Format("{0}/{1}", RealEquipmentCount, db.Admiral.MaxEquipmentCount);
-			if (RealEquipmentCount > db.Admiral.MaxEquipmentCount + 3 - 20)
+			EquipmentCount.Text = string.Format("{0}/{1}", db.Admiral.RealEquipmentCount, db.Admiral.MaxEquipmentCount);
+			if (db.Admiral.RealEquipmentCount > db.Admiral.MaxEquipmentCount + 3 - 20)
 			{
 				EquipmentCount.BackColor = Utility.Configuration.Config.UI.Headquarters_ShipCountOverBG;
 				EquipmentCount.ForeColor = Utility.Configuration.Config.UI.Headquarters_ShipCountOverFG;
@@ -320,7 +320,7 @@ public partial class HeadquartersViewModel : AnchorableViewModel
 				EquipmentCount.BackColor = System.Drawing.Color.Transparent;
 				EquipmentCount.ForeColor = Utility.Configuration.Config.UI.ForeColor;
 			}
-			EquipmentCount.Tag = RealEquipmentCount >= db.Admiral.MaxEquipmentCount;
+			EquipmentCount.Tag = db.Admiral.RealEquipmentCount >= db.Admiral.MaxEquipmentCount;
 
 		}
 		// FlowPanelFleet.ResumeLayout();
@@ -659,30 +659,4 @@ public partial class HeadquartersViewModel : AnchorableViewModel
 
 		MessageBox.Show(sb.ToString(), FormHeadquarters.ListOfOwnedItems, MessageBoxButton.OK, MessageBoxImage.Information);
 	}
-
-	private int RealShipCount
-	{
-		get
-		{
-			if (KCDatabase.Instance.Battle != null)
-				return KCDatabase.Instance.Ships.Count + KCDatabase.Instance.Battle.DroppedShipCount;
-
-			return KCDatabase.Instance.Ships.Count;
-		}
-	}
-
-	private int RealEquipmentCount
-	{
-		get
-		{
-			int equipmentCount = KCDatabase.Instance.Equipments.Values
-				.Count(e => e.MasterEquipment.UsesSlotSpace());
-
-			if (KCDatabase.Instance.Battle != null)
-				return equipmentCount + KCDatabase.Instance.Battle.DroppedEquipmentCount;
-
-			return equipmentCount;
-		}
-	}
-
 }


### PR DESCRIPTION
Changed the logic to
- If there's a drop => report drop
- Else that means there's no drop, then only report the no drop if HQ view counts are not capped, since this one is updated unlike the KCDatabase.Admiral counts