### PR TITLE
Add boss-reached filter to sortie record viewer

### DIFF
--- a/ElectronicObserver/Window/Tools/SortieRecordViewer/Extensions.cs
+++ b/ElectronicObserver/Window/Tools/SortieRecordViewer/Extensions.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
+using ElectronicObserver.Core.Types;
 using ElectronicObserver.Database;
 using ElectronicObserver.Database.Expedition;
 using ElectronicObserver.Database.KancolleApi;
@@ -455,6 +456,12 @@ public static class Extensions
 	public static bool IsMapProgressApi(this ApiFile apiFile) => apiFile.Name is
 		"api_req_map/start" or
 		"api_req_map/next";
+
+	// true if the sortie visited a boss battle cell; only inspects map progress files
+	public static bool ReachedBossNode(this IEnumerable<ApiFile> apiFiles) => apiFiles
+		.Where(f => f.IsMapProgressApi())
+		.Select(f => f.GetMapProgressApiData())
+		.Any(data => data?.ApiColorNo is CellType.BossBattle);
 
 	private static Func<ElectronicObserverContext, List<int>, IAsyncEnumerable<SortieRecord>> SortieQuery { get; }
 		= EF.CompileAsyncQuery((ElectronicObserverContext db, List<int> idsToLoad)

--- a/ElectronicObserver/Window/Tools/SortieRecordViewer/SortieRecordViewerResources.en.resx
+++ b/ElectronicObserver/Window/Tools/SortieRecordViewer/SortieRecordViewerResources.en.resx
@@ -168,4 +168,7 @@
   <data name="ShowQuickExport" xml:space="preserve">
     <value>Show quick export</value>
   </data>
+  <data name="BossNodeOnly" xml:space="preserve">
+    <value>Reached boss</value>
+  </data>
 </root>

--- a/ElectronicObserver/Window/Tools/SortieRecordViewer/SortieRecordViewerResources.resx
+++ b/ElectronicObserver/Window/Tools/SortieRecordViewer/SortieRecordViewerResources.resx
@@ -148,4 +148,7 @@
   <data name="ShowQuickExport" xml:space="preserve">
     <value>クイックエクスポートを表示</value>
   </data>
+  <data name="BossNodeOnly" xml:space="preserve">
+    <value>ボス到達</value>
+  </data>
 </root>

--- a/ElectronicObserver/Window/Tools/SortieRecordViewer/SortieRecordViewerResources.zh-TW.resx
+++ b/ElectronicObserver/Window/Tools/SortieRecordViewer/SortieRecordViewerResources.zh-TW.resx
@@ -168,4 +168,7 @@
   <data name="ShowQuickExport" xml:space="preserve">
     <value>顯示快速匯出</value>
   </data>
+  <data name="BossNodeOnly" xml:space="preserve">
+    <value>抵達Boss</value>
+  </data>
 </root>

--- a/ElectronicObserver/Window/Tools/SortieRecordViewer/SortieRecordViewerTranslationViewModel.cs
+++ b/ElectronicObserver/Window/Tools/SortieRecordViewer/SortieRecordViewerTranslationViewModel.cs
@@ -16,6 +16,7 @@ public class SortieRecordViewerTranslationViewModel : TranslationBaseViewModel
 
 	public string View => MainResources.View;
 	public string ShowQuickExport => SortieRecordViewerResources.ShowQuickExport;
+	public string BossNodeOnly => SortieRecordViewerResources.BossNodeOnly;
 
 	public string Start => DropRecordViewerResources.Start;
 	public string End => DropRecordViewerResources.End;

--- a/ElectronicObserver/Window/Tools/SortieRecordViewer/SortieRecordViewerViewModel.cs
+++ b/ElectronicObserver/Window/Tools/SortieRecordViewer/SortieRecordViewerViewModel.cs
@@ -81,6 +81,7 @@ public partial class SortieRecordViewerViewModel : WindowViewModelBase
 
 	private SortieCostConfigurationViewModel SortieCostConfiguration { get; } = new();
 	[ObservableProperty] private bool _showQuickExport;
+	[ObservableProperty] private bool _bossNodeOnly;
 
 	public bool IsDebug =>
 #if DEBUG
@@ -170,7 +171,17 @@ public partial class SortieRecordViewerViewModel : WindowViewModelBase
 			DateTime end = DateTimeEnd.ToUniversalTime();
 
 			List<SortieRecordViewModel> sorties = await Task.Run(async () =>
-				await SortieQuery(Db, world, map, begin, end, ImageLoadService).ToListAsync(ct), ct);
+			{
+				List<SortieRecordViewModel> result =
+					await SortieQuery(Db, world, map, begin, end, ImageLoadService).ToListAsync(ct);
+
+				if (BossNodeOnly)
+				{
+					result = await FilterReachedBoss(result, ct);
+				}
+
+				return result;
+			}, ct);
 
 			Sorties.Clear();
 
@@ -191,6 +202,32 @@ public partial class SortieRecordViewerViewModel : WindowViewModelBase
 		{
 			Logger.Add(2, $"Unknown error while loading data: {e.Message}{e.StackTrace}");
 		}
+	}
+
+	private async Task<List<SortieRecordViewModel>> FilterReachedBoss(
+		List<SortieRecordViewModel> sorties, CancellationToken ct)
+	{
+		List<int> ids = sorties.Select(s => s.Model.Id).ToList();
+
+		if (ids.Count is 0) return sorties;
+
+		// only the small map progress files are needed to detect the boss node,
+		// so the full api file set is intentionally not loaded here
+		var mapFiles = await Db.ApiFiles
+			.AsNoTracking()
+			.Where(f => f.SortieRecordId != null && ids.Contains(f.SortieRecordId.Value))
+			.Where(f => f.Name == "api_req_map/start" || f.Name == "api_req_map/next")
+			.ToListAsync(ct);
+
+		HashSet<int> reachedBoss = mapFiles
+			.GroupBy(f => f.SortieRecordId!.Value)
+			.Where(g => g.ReachedBossNode())
+			.Select(g => g.Key)
+			.ToHashSet();
+
+		return sorties
+			.Where(s => reachedBoss.Contains(s.Model.Id))
+			.ToList();
 	}
 
 	[RelayCommand]

--- a/ElectronicObserver/Window/Tools/SortieRecordViewer/SortieRecordViewerWindow.xaml
+++ b/ElectronicObserver/Window/Tools/SortieRecordViewer/SortieRecordViewerWindow.xaml
@@ -167,6 +167,16 @@
 					<ui:SimpleTimePicker Culture="ja-JP" SelectedDateTime="{Binding TimeEnd}" />
 				</StackPanel>
 
+				<CheckBox
+					Grid.Row="0"
+					Grid.Column="3"
+					Grid.ColumnSpan="3"
+					Margin="2"
+					VerticalAlignment="Center"
+					Content="{Binding SortieRecordViewer.BossNodeOnly}"
+					IsChecked="{Binding BossNodeOnly}"
+					/>
+
 				<ComboBox
 					Grid.Row="1"
 					Grid.Column="3"


### PR DESCRIPTION
Add a checkbox to the sortie record viewer that filters the results to only sorties whose route reached a boss battle cell.

<img width="1280" height="318" alt="image" src="https://github.com/user-attachments/assets/fa11cb5c-c233-4d81-a58d-c84dd2aecf6c" />
